### PR TITLE
Make `yup` call -Syu instead of -Syyu

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -35,7 +35,7 @@ const Version = "0.1.7-beta"
 
 // Constants for output
 const help = `Usage:
-    yup                 Updates AUR and pacman packages (Like -Syyu)
+    yup                 Updates AUR and pacman packages (Like -Syu)
     yup <package(s)>    Searches for that packages and provides an install dialogue
 
 Operations:

--- a/update/update.go
+++ b/update/update.go
@@ -23,7 +23,7 @@ type installedPack struct {
 // Update runs system update from repos
 func Update() error {
 	output.Printf("Updating from local repositories")
-	cmd := exec.Command("sudo", "pacman", "-Syyu")
+	cmd := exec.Command("sudo", "pacman", "-Syu")
 	output.SetStd(cmd)
 	if err := cmd.Run(); err != nil {
 		return err


### PR DESCRIPTION
There's no need to download the package databases every time you update under normal conditions and it puts unnecessary strain on the mirrors.  
See: https://wiki.archlinux.org/index.php/Mirrors#Force_pacman_to_refresh_the_package_lists