### PR TITLE
added catch for nothing to clean

### DIFF
--- a/clean/clean.go
+++ b/clean/clean.go
@@ -33,6 +33,9 @@ func Clean() error {
 				packs = append(packs, pack)
 			}
 		}
+	} else {
+		output.Printf("No unused dependencies found")
+		return nil
 	}
 
 	// Remove


### PR DESCRIPTION
Stops an error code when there are no unused dependency packages to install when running the command `yup -c`