### PR TITLE
Fixed newer packages mistakenly considered as older

### DIFF
--- a/update/update.go
+++ b/update/update.go
@@ -169,6 +169,13 @@ func newerVersion(oldVersion, newVersion string) bool {
 		if oldVer[0] == newVer[0] {
 			relOld, _ := strconv.Atoi(oldVer[1])
 			relNew, _ := strconv.Atoi(newVer[1])
+			if len(rSplitO) > 1 && len(rSplitN) > 1 {
+				rSplitOld, _ := strconv.Atoi(rSplitO[1])
+				rSplitNew, _ := strconv.Atoi(rSplitN[1])
+				if rSplitOld < rSplitNew {
+					return true
+				}
+			}
 			if relOld < relNew {
 				return true
 			}


### PR DESCRIPTION
I had this prompt while using the program today.

![image](https://user-images.githubusercontent.com/1565959/85203011-f46c3b00-b30a-11ea-89c1-7f956fe8a25b.png)

After investigating the code, I realized that the number after the `.r` is being ignored.

With this exact setup (where `oldVersion` and `newVersion` are in the form of `456.r4x-1`), the `oldVer` and `newVer` arrays [becomes the same](https://user-images.githubusercontent.com/1565959/85203100-8c6a2480-b30b-11ea-97ac-a9e1b76eb8e1.png), and [returns false](https://github.com/ericm/yup/blob/674b8e2e6c5ff86dad64ec6dc3066f95eba94b60/update/update.go#L175).

I made a simple fix for now, but it probably needs a deeper look. I couldn't find any reliant package version conventions online, and I am not sure how the program should behave if the `.rXX` is being added or removed. For now, I just checked if it existed on both versions.