### PR TITLE
Pacman search: Return error if exec failed

### DIFF
--- a/search/search.go
+++ b/search/search.go
@@ -147,7 +147,8 @@ func Pacman(query string, print bool, installed bool) ([]output.Package, error) 
 	search := exec.Command("pacman", append([]string{"-Ss"}, strings.Split(query, " ")...)...)
 	run, err := search.Output()
 	if err != nil {
-		return []output.Package{}, nil
+		execErr := err.(*exec.ExitError)
+		return []output.Package{}, fmt.Errorf("%w: %s", execErr, execErr.Stderr)
 	}
 
 	// Find Package vals


### PR DESCRIPTION
Also include stderr in wrapped error to give the user a hint about
the cause of the error.

Improves error reporting:

```
→ ./yup emacs
==> Searching and sorting your query...
==> exit status 1: error: database 'core' is not valid (invalid or corrupted database (PGP signature))
error: database 'extra' is not valid (invalid or corrupted database (PGP signature))
error: database 'community' is not valid (invalid or corrupted database (PGP signature))
```

Instead of

```
==> Searching and sorting your query...
==> exit status 1
```

